### PR TITLE
readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Applications on Autopilot
 *A demonstration of the autopilot pattern for self-operating microservices, designed as a workshop or tutorial.*
 
 
-Microservices and [Docker](https://www.docker.com) go together like chocolate and peanut butter: microservice architectures provide organizations a tool to manage complexity of the development process, and application containers provide a new means to manage the dependencies and deployment of those microservices. But deploying and connecting those services together is still a challenge because it forces developers to design for operationalization.
+Microservices and Docker go together like chocolate and peanut butter: microservice architectures provide organizations a tool to manage complexity of the development process, and application containers provide a new means to manage the dependencies and deployment of those microservices. But deploying and connecting those services together is still a challenge because it forces developers to design for operationalization.
 
 The [Autopilot Pattern](http://autopilotpattern.io/) is a powerful design pattern to solving this problem. By pushing the responsibility for understanding startup, shutdown, scaling, and recovery from failure into the application, we can build intelligent architectures that minimize human intervention in operation. But we can't rewrite all our applications at once, so we need a way to build application containers that can knit together legacy and greenfield applications alike.
 
@@ -13,7 +13,7 @@ This project demonstrates this design pattern by applying it to a simple microse
 
 ### Getting started
 
-This project requires a Docker host and client, as well as Docker Compose. The latest version of [Docker](https://www.docker.com) will provide a suitable environment for users on OS X or Windows.
+This project requires a Docker host and client, as well as Docker Compose. The [Docker Toolbox](https://www.docker.com/products/docker-toolbox) will provide a suitable environment for users on OS X or Windows.
 
 ### Project architecture
 


### PR DESCRIPTION
- no links in the intro graf
- keep the link to the Docker Toolbox, since that landing page is easier to navigate
